### PR TITLE
Pass error to fallBack on the server

### DIFF
--- a/src/server.jsx
+++ b/src/server.jsx
@@ -63,8 +63,8 @@ export function _render(self, ProvideContext) {
     try {
       const __html = renderToStaticMarkup(elementWithProviders);
       return <div dangerouslySetInnerHTML={{ __html }} />;
-    } catch (e) {
-      return <>{self.props.fallBack()}</>;
+    } catch (error) {
+      return <>{self.props.fallBack({ error })}</>;
     }
   });
 }


### PR DESCRIPTION
`error` and `errorinfo` are passed on the client, so would it make sense to also pass the `error` on the server?